### PR TITLE
Fixing issue where sending value data is not useable due to wrong end…

### DIFF
--- a/pyfttt/sending.py
+++ b/pyfttt/sending.py
@@ -22,8 +22,7 @@ def send_event(api_key, event, value1=None, value2=None, value3=None):
 
     """
 
-    url = 'https://maker.ifttt.com/trigger/{e}/with/key/{k}/'.format(e=event,
+    url = 'https://maker.ifttt.com/trigger/{e}/json/with/key/{k}/'.format(e=event,
                                                                      k=api_key)
     payload = {'value1': value1, 'value2': value2, 'value3': value3}
     return requests.post(url, data=payload)
-

--- a/pyfttt/sending.py
+++ b/pyfttt/sending.py
@@ -26,3 +26,4 @@ def send_event(api_key, event, value1=None, value2=None, value3=None):
                                                                      k=api_key)
     payload = {'value1': value1, 'value2': value2, 'value3': value3}
     return requests.post(url, data=payload)
+


### PR DESCRIPTION
I created an issue about this, but thought it might be easier if I did a PR. I've tested this with calling the pyfttt directly and also fixing it in Home Assistant. With this fix we can get the data passed in from the 3 value variables.